### PR TITLE
Create and view tools

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const cookieSession = require("cookie-session");
 const indexRouter = require("./routes/indexRouter");
 const recipeRouter = require("./routes/reciperRouter");
 const supplierRouter = require("./routes/supplierRouter");
+const toolRouter = require("./routes/toolRouter"); // postfix .js?
 
 // create new instance of express app and set port
 const app = express();
@@ -63,6 +64,7 @@ app.use(
 app.use("/", indexRouter);
 app.use("/recipes", recipeRouter);
 app.use("/supplier", supplierRouter);
+app.use("/tools", toolRouter);
 
 // set function to respond to any unhandled GET request
 app.get("*", (req, res, next) => {

--- a/routes/supplierRouter.js
+++ b/routes/supplierRouter.js
@@ -60,18 +60,34 @@ router.get("/add_tool", sessionMiddleware.ifNotLoggedin, (req, res, next) => {
 router.post("/add_tool", sessionMiddleware.ifNotLoggedin, (req, res, next)=>{
     try {
         const { name, description } = req.body;
-
+        // TODO: Update this logic so if the tool already exists a reference
+        // is instead made to it.
+        // I was trying to do a stored procedure for this but was unable to get it to work ideally. So instead
+        // I am working on just trying to do a multi-line statement.
+        //var my_sql_con = mysql.createConnection({multipleStatements: true});
+        //my_sql.pool.multipleStatements = true;
         mysql.pool.query(
-            "INSERT INTO Tool (name, description) VALUES(?, ?)",
-            [name, description],
+            "INSERT INTO Tool (name, description) VALUES(?, ?); INSERT INTO manufactures (s_id, t_id) VALUES ((SELECT s_id FROM Supplier WHERE username = ?), (SELECT t_id FROM Tool WHERE name = ?))",
+            [name, description, req.session.username, name],
             function (err, result) {
                 if(err)
-                    res.status(500).send("Error creating tool.");
+                {
+                    //my_sql.pool.multipleStatements = false;
+                    res.status(500).send("Error creating tool.\n" + err);
+                }
                 else
-                    res.status(200).send("Created tool.");
+                {
+                    //my_sql.pool.multipleStatements = false;
+                    // Tool created; now register it with the manufacturer.
+                    //mysql.pool.query("CALL registerUserNewTool(?, ?)",
+                    // I couldn't figure out stored procedures so I'm doing
+                    // this instead for now:
+                    res.status(200).send("Created tool and registered with manufacturer");
+                }
             }
         ); // end query
     } catch (err) {
+        //my_sql.pool.multipleStatements = false;
         res.status(500).send("Unexpected exception while creating tool.");
     } // end catch
 }); // end router.post

--- a/routes/supplierRouter.js
+++ b/routes/supplierRouter.js
@@ -67,8 +67,8 @@ router.post("/add_tool", sessionMiddleware.ifNotLoggedin, (req, res, next)=>{
         //var my_sql_con = mysql.createConnection({multipleStatements: true});
         //my_sql.pool.multipleStatements = true;
         mysql.pool.query(
-            "INSERT INTO Tool (name, description) VALUES(?, ?); INSERT INTO manufactures (s_id, t_id) VALUES ((SELECT s_id FROM Supplier WHERE username = ?), (SELECT t_id FROM Tool WHERE name = ?))",
-            [name, description, req.session.username, name],
+            "INSERT INTO Tool (name, description) VALUES(?, ?); INSERT INTO manufactures (s_id, t_id) VALUES ((SELECT s_id FROM Supplier WHERE username = ?), (SELECT t_id FROM Tool WHERE name = ? AND description = ?))",
+            [name, description, req.session.username, name, description],
             function (err, result) {
                 if(err)
                 {
@@ -82,7 +82,8 @@ router.post("/add_tool", sessionMiddleware.ifNotLoggedin, (req, res, next)=>{
                     //mysql.pool.query("CALL registerUserNewTool(?, ?)",
                     // I couldn't figure out stored procedures so I'm doing
                     // this instead for now:
-                    res.status(200).send("Created tool and registered with manufacturer");
+                    //res.status(200).send("Created tool and registered with manufacturer");
+                    res.status(200).redirect("/supplier");
                 }
             }
         ); // end query

--- a/routes/supplierRouter.js
+++ b/routes/supplierRouter.js
@@ -14,7 +14,7 @@ try {
     // to double-up queries? Might no longer be appropriate to call the page
     // parameter "tools" anymore.
     mysql.pool.query(
-        "SELECT * FROM Tool t INNER JOIN manufactures m ON m.t_id = t.t_id INNER JOIN Supplier s ON s.s_id = m.s_id WHERE username=? ORDER BY t.t_id DESC;",
+        "SELECT t.name, t.description FROM Tool t INNER JOIN manufactures m ON m.t_id = t.t_id INNER JOIN Supplier s ON s.s_id = m.s_id WHERE username=? ORDER BY t.t_id DESC;",
         [currentUser], // This parameter is given to the SQL.
         function(err, rows, fields) {
             if(!err) { // No SQL Error

--- a/routes/supplierRouter.js
+++ b/routes/supplierRouter.js
@@ -27,9 +27,32 @@ router.get(
 
 // add new tool page
 router.get("/add_tool", sessionMiddleware.ifNotLoggedin, (req, res, next) => {
-  res
-    .status(200)
-    .render("add_tool_page", { css: ["add_tool.css"], username: currentUSer });
+    let currentUser = req.session.username; // Needed?
+    res.status(200).render(
+        "add_tool_page",
+        { css: ["add_tool.css"], username: currentUser }
+    );
 });
+
+// Allow synthesis of new tool using existing form.
+// I was originally going to do this in the tool router but I changed my mind.
+router.post("/add_tool", sessionMiddleware.ifNotLoggedin, (req, res, next)=>{
+    try {
+        const { name, description } = req.body;
+
+        mysql.pool.query(
+            "INSERT INTO Tool (name, description) VALUES(?, ?)",
+            [name, description],
+            function (err, result) {
+                if(err)
+                    res.status(500).send("Error creating tool.");
+                else
+                    res.status(200).send("Created tool.");
+            }
+        ); // end query
+    } catch (err) {
+        res.status(500).send("Unexpected exception while creating tool.");
+    } // end catch
+}); // end router.post
 
 module.exports = router;

--- a/routes/toolRouter.js
+++ b/routes/toolRouter.js
@@ -1,0 +1,38 @@
+// toolRouter.js
+// Handles tool-related database operations
+
+const express = require("express");
+const mysql = require("../dbcon.js"); // Not sure if this should be a hard-
+                                      // -coded path...
+const sessionMiddleware = require("../sessionMiddleware.js");
+
+const router = express.Router();
+
+// No tools homepage, panic.
+router.get("/", (req, res, next)=>{
+    res.send("There is no tools home page");
+});
+
+// Add a new tool to the database.
+router.post("/create", sessionMiddleware.ifNotLoggedin, (req, res, next)=>{
+    try {
+        const { name, description } = req.body;
+
+        mysql.pool.query(
+            "INSERT INTO Tool (name, description) VALUES(?, ?)",
+            [name, description],
+            function (err, result) {
+                if(err)
+                    res.status(500).send("Error creating tool.");
+                else
+                    res.status(200).send("Created tool.");
+            }
+        ); // end query
+    } catch (err) {
+        res.status(500).send("Unexpected exception while creating tool.");
+    } // end catch
+}); // end router.post
+
+// VERY IMPORTANT LINE easy for me to forget:
+module.exports = router
+

--- a/routes/toolRouter.js
+++ b/routes/toolRouter.js
@@ -13,6 +13,27 @@ router.get("/", (req, res, next)=>{
     res.send("There is no tools home page");
 });
 
+// Show the details for a particular tool.
+router.get("/:t_id", sessionMiddleware.ifNotLoggedin, (req, res, next)=>{
+    let current_user = req.session.username;
+    let tool_id = req.params.t_id;
+    mysql.pool.query(
+        `SELECT * FROM Tool t WHERE t.t_id = ${tool_id}`,
+        function (err, rows, fields) { // error handler
+            if(err) // If there was an error
+                res.status(500).send("Couldn't find that tool: " + tool_id);
+            res.status(200).render("tool_detail", {
+                css: [tool_detail.css],
+                tool: rows[0],
+                username: currentUser
+            }); // end res.status
+        } // end response function
+    ); // End mysql.pool.query
+}); // End router.get()
+
+/* If you want to add tool creation that's fine, and you'd do so here,
+ * but for now this router will just be for SELECT queries (that you don't
+ * have to be a supplier to see)
 // Add a new tool to the database.
 router.post("/create", sessionMiddleware.ifNotLoggedin, (req, res, next)=>{
     try {
@@ -32,6 +53,7 @@ router.post("/create", sessionMiddleware.ifNotLoggedin, (req, res, next)=>{
         res.status(500).send("Unexpected exception while creating tool.");
     } // end catch
 }); // end router.post
+*/
 
 // VERY IMPORTANT LINE easy for me to forget:
 module.exports = router

--- a/views/supplier.handlebars
+++ b/views/supplier.handlebars
@@ -16,7 +16,7 @@
                 <!--Opting not to use a template for this since tools are
                 so simple to ennumerate.-->
                 {{#each tools}}
-                    <li><strong>{{tools.name}}:</strong> {{tools.description}}</li>
+                    <li><strong>{{name}}:</strong> {{description}}</li>
                 {{/each}}
             </ul>
             <a href="/supplier/add_tool" class="supplier-button">Add Tool</a>

--- a/views/supplier.handlebars
+++ b/views/supplier.handlebars
@@ -12,10 +12,12 @@
             <a href="/supplier/add_ingredient" class="supplier-button">Add Ingredient</a>
         </div>
         <div class="tool-container">
-            <ul class="tools">
-                <li>tool</li>
-                <li>tool</li>
-                <li>tool</li>
+            <ul class="tools"> <!--Using handlebars to show off each tool.-->
+                <!--Opting not to use a template for this since tools are
+                so simple to ennumerate.-->
+                {{#each tools}}
+                    <li><strong>{{tools.name}}:</strong> {{tools.description}}</li>
+                {{/each}}
             </ul>
             <a href="/supplier/add_tool" class="supplier-button">Add Tool</a>
         </div>


### PR DESCRIPTION
This work allows tools to be created from the already existing interface by which suppliers create new tools. Notably, tools are currently **visible to the supplier who created them;** I did not modify the recipe viewer.

**Important: In order for this to work, your `dbcon.js` file _must_ contain the property `multipleStatements : true`.** Because we do not track dbcon.js, people will have to make this change individually. This will not break any existing functionality, but to use the tool creation functionality this must be added. I got the idea from a [stack overflow question](https://stackoverflow.com/questions/23266854/node-mysql-multiple-statements-in-one-query) as a way to avoid writing a stored procedure (which I would then have to share with everybody else; for now, I will try to keep it simple and keep everything inline). That being said, in the long run it may be more appropriate to use stored procedures than multi-line statements.

Things still to be done regarding tools:
* Allow suppliers to add already-existing tools to their "manufactures" list, so multiple suppliers can manufacture the same tool.
* Move from multipleStatments to stored procedures.
* Return to the supplier page after creating a tool instead of using `res.status(200).send()`.

I'm putting this out there now so that @taylozac can inspect my handling of `supplier/`, which may be appropriate since they are working on the ingredients list (which according to our mockup must also be shown in the same view).