### PR TITLE
Fix Ingredient INSERT

### DIFF
--- a/routes/supplierRouter.js
+++ b/routes/supplierRouter.js
@@ -173,10 +173,18 @@ router.post("/add_tool", sessionMiddleware.ifNotLoggedin, (req, res, next)=>{
 //
 router.post("/add_ingredient", sessionMiddleware.ifNotLoggedin, (req, res, next) => {
     try {
-        const { name, description } = req.body;
+        const { name, description, organic, amount, shelf_life } = req.body;
+        //var organic_bool = organic != NULL || organic == "organic"; //HTML tomfoolery
+        // console.log("Organic: " + organic);
+        var organic_bool = false;
+        // Weird how POST handles checkbox input. lol
+        try {
+            if(organic != undefined) // or == "organic"
+                organic_bool = true;
+        } catch(r) { }
         mysql.pool.query(
-            "INSERT INTO Ingredient (name, description) VALUES(?, ?); INSERT INTO stocks (s_id, i_id) VALUES ((SELECT s_id FROM Supplier WHERE username = ?), (SELECT i_id FROM Ingredient WHERE name = ? AND description = ?))",
-            [name, description, req.session.username, name, description],
+            "INSERT INTO Ingredient (name, description, organic, shelf_life) VALUES(?, ?, ?, ?); INSERT INTO stocks (s_id, i_id, amount) VALUES ((SELECT s_id FROM Supplier WHERE username = ?), (SELECT i_id FROM Ingredient WHERE name = ? AND description = ?), ?)",
+            [name, description, organic_bool, shelf_life, req.session.username, name, description, amount],
             function (err, result) {
                 if(err)
                 {

--- a/views/add_ingredient_page.handlebars
+++ b/views/add_ingredient_page.handlebars
@@ -6,6 +6,7 @@
             <hr class="form-logo">
             <h3>Add New Ingredient</h3>
         </div>
+        <!--Interesting; in future maybe have action URL separate?-->
         <form id="new-recipe-form" method="post" action="">
             <span class="form-input-container">
                 <i class="form-field-icon fas fa-utensils fa-lg"></i>
@@ -15,6 +16,16 @@
                 <i class="form-field-icon far fa-sticky-note fa-lg"></i>
                 <textarea name="description" id="ingredient-desription" placeholder="decription..." cols="30"
                     rows="10"></textarea>
+            </span>
+            <span class="form-input-container">
+                <label for="organic">Organic?</label>
+                <input type="checkbox" id="organic" name="organic" value="organic" style="-webkit-appearance: checkbox;"><br>
+            </span>
+            <span class="form-input-container">
+                Shelf life? <input class="form-input-field" type="date" name="shelf_life">
+            </span>
+            <span class="form-input-container">
+                Amount to stock? <input class="form-input-field" type="text" name="amount">
             </span>
             <span class="form-button-container">
                 <input class="form-button submit" type="submit" value="Add Ingredient">


### PR DESCRIPTION
I added some bells and whistles to the HTML form and supplier router to smooth along the process of adding new ingredients to the database. Now we can correctly insert new items with "amount" (stocks relationship), "organic" (ingredient), and shelf_life (ingredient) properties. This should fix the issue @Michael-Hathaway was having earlier, notably:

> I don’t remember who implemented the ingredient functionality for suppliers, but I just got the following error when trying to add an ingredient: Error creating ingredient. Error: ER_NO_DEFAULT_FOR_FIELD: Field ‘amount’ doesn’t have a default value

I didn't get this error on my end, so I can't confirm this is a fix; however, these new changes are just fine and seem to address the described issue. Michael, could you verify that this fixes the problem you were having?